### PR TITLE
Change Pager reference to Jekyll::Paginate::Pager

### DIFF
--- a/tags-pagination.rb
+++ b/tags-pagination.rb
@@ -39,7 +39,7 @@ module Jekyll
     end
   end
 
-  class TagPager < Pager 
+  class TagPager < Jekyll::Paginate::Pager 
     attr_reader :tag
 
     def initialize(site, page, all_posts, tag, num_pages = nil)


### PR DESCRIPTION
As of Jekyll 2.1.0, `Pager` was moved to `jekyll-paginate`; therefore references for `Pager` must be changed to `Jekyll::Paginate::Pager`